### PR TITLE
fix: update language version range to 0.16-0.21 and fix ledger detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.18] - 2026-03-24
+
+### Fixed
+
+- **Language Version Range** - Updated supported Compact language version from `0.16-0.18` to `0.16-0.21` (compiler 0.29.0)
+  - All pragma examples, prompt templates, and validation suggestions now use `>= 0.16 && <= 0.21`
+  - Contracts using `pragma language_version >= 0.20` no longer fail with version mismatch
+
+- **Ledger Detection in Static Analysis** - `midnight-analyze-contract` now detects new-style ledger declarations (`export ledger name: Type;`) in addition to legacy block-style (`ledger { ... }`)
+  - Fixes `hasLedger: false` and `publicState: 0` when ledger fields exist
+
+### Updated
+
+- Embedded documentation, code examples, and syntax reference updated to reflect Compact v0.21
+- `SYNTAX_MAINTENANCE.md` version history table updated
+
 ## [0.2.17] - 2026-03-03
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ All tools are prefixed with `midnight-` (e.g., `midnight-search-compact`).
 The `midnight-compile-contract` tool validates Compact code using a hosted compiler service:
 
 ```
-✅ Compilation successful (Compiler v0.18.0) in 2841ms
+✅ Compilation successful (Compiler v0.29.0) in 2841ms
 ```
 
 - **Fast mode** (`skipZk=true`): Syntax validation in ~1-2 seconds
@@ -151,7 +151,7 @@ This catches semantic errors that static analysis misses (sealed fields, disclos
 
 Quick references available offline:
 
-- Compact syntax guide (v0.16-0.18)
+- Compact syntax guide (v0.16-0.21)
 - SDK API reference
 - OpenZeppelin contracts
 - Tokenomics overview
@@ -166,7 +166,7 @@ Quick references available offline:
 | ------------------------- | -------- | ------------------------------------------------------- |
 | `deprecated_ledger_block` | P0       | Catches `ledger { }` → use `export ledger field: Type;` |
 | `invalid_void_type`       | P0       | Catches `Void` → use `[]` (empty tuple)                 |
-| `invalid_pragma_format`   | P0       | Catches old pragma → use `>= 0.16 && <= 0.18`           |
+| `invalid_pragma_format`   | P0       | Catches old pragma → use `>= 0.16 && <= 0.21`           |
 | `unexported_enum`         | P1       | Enums need `export` for TypeScript access               |
 | `module_level_const`      | P0       | Use `pure circuit` instead                              |
 | + 10 more checks          | P1-P2    | Overflow, division, assertions, etc.                    |

--- a/docs/API.md
+++ b/docs/API.md
@@ -139,7 +139,7 @@ Compile Compact code using the hosted compiler service. Returns real compiler er
 // Output (success)
 {
   success: true;
-  message: string;           // "✅ Compilation successful (Compiler v0.18.0) in 2841ms"
+  message: string;           // "✅ Compilation successful (Compiler v0.29.0) in 2841ms"
   validationType: "compiler";
   compilerVersion: string;
   compilationMode: "syntax-only" | "full";

--- a/docs/SYNTAX_MAINTENANCE.md
+++ b/docs/SYNTAX_MAINTENANCE.md
@@ -19,7 +19,7 @@ Update the embedded documentation:
 
 ```typescript
 // Look for this section and update:
-"midnight://docs/compact-reference": `# Compact Language Syntax Reference (v0.16 - v0.18)
+"midnight://docs/compact-reference": `# Compact Language Syntax Reference (v0.16 - v0.21)
 ```
 
 **Checklist:**
@@ -102,7 +102,7 @@ npm test
 npm run build
 
 # 3. Manual test with a real contract
-echo 'pragma language_version >= 0.16 && <= 0.18;
+echo 'pragma language_version >= 0.16 && <= 0.21;
 import CompactStandardLibrary;
 export ledger counter: Counter;
 export circuit inc(): [] { counter.increment(1); }' > /tmp/test.compact
@@ -115,7 +115,8 @@ export circuit inc(): [] { counter.increment(1); }' > /tmp/test.compact
 
 | Compact Version | midnight-mcp Version | Key Changes                                          |
 | --------------- | -------------------- | ---------------------------------------------------- |
-| 0.16 - 0.18     | 0.1.33+              | Individual ledger decls, `[]` return, bounded pragma |
+| 0.20 - 0.21     | 0.2.18+              | Updated pragma range for compiler 0.28-0.29          |
+| 0.16 - 0.18     | 0.1.33 - 0.2.17      | Individual ledger decls, `[]` return, bounded pragma |
 | 0.14 - 0.15     | 0.1.0 - 0.1.32       | `ledger {}` block, `Cell<T>` wrapper                 |
 
 ## Finding Syntax Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-mcp",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Model Context Protocol Server for Midnight Blockchain Development",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config/compact-version.ts
+++ b/src/config/compact-version.ts
@@ -26,9 +26,9 @@ export const COMPACT_VERSION = {
   /** Minimum supported version */
   min: "0.16",
   /** Maximum supported version */
-  max: "0.18",
+  max: "0.21",
   /** When this config was last updated */
-  lastUpdated: "2025-01-26",
+  lastUpdated: "2026-03-24",
   /** Source of truth for syntax patterns */
   referenceSource: "https://github.com/piotr-iohk/template-contract",
 };

--- a/src/pipeline/parser.ts
+++ b/src/pipeline/parser.ts
@@ -103,7 +103,7 @@ export function parseCompactFile(path: string, content: string): ParsedFile {
     }
   }
 
-  // Parse ledger block
+  // Parse ledger block (legacy block-style: `ledger { ... }`)
   const ledgerRegex = /ledger\s*\{([^}]*(?:\{[^}]*\}[^}]*)*)\}/gs;
   let ledgerMatch;
   while ((ledgerMatch = ledgerRegex.exec(content)) !== null) {
@@ -140,6 +140,31 @@ export function parseCompactFile(path: string, content: string): ParsedFile {
         returnType: fieldMatch[3].trim(),
       });
     }
+  }
+
+  // Parse new-style ledger declarations: `[export] ledger fieldName: Type;`
+  const newLedgerRegex =
+    /(?:(export)\s+)?ledger\s+(\w+)\s*:\s*([^;]+);/gm;
+  let newLedgerMatch;
+  while ((newLedgerMatch = newLedgerRegex.exec(content)) !== null) {
+    hasLedger = true;
+    const isExport = newLedgerMatch[1] === "export";
+    const fieldName = newLedgerMatch[2];
+    const fieldType = newLedgerMatch[3].trim();
+    const startLine = content
+      .substring(0, newLedgerMatch.index)
+      .split("\n").length;
+
+    codeUnits.push({
+      type: "ledger",
+      name: fieldName,
+      code: newLedgerMatch[0].trim(),
+      startLine,
+      endLine: startLine,
+      isPublic: isExport,
+      isPrivate: !isExport,
+      returnType: fieldType,
+    });
   }
 
   // Parse circuit definitions

--- a/src/prompts/templates.ts
+++ b/src/prompts/templates.ts
@@ -167,7 +167,7 @@ function generateCreateContractPrompt(
 Call \`midnight-get-latest-syntax\` FIRST to get:
 - The \`quickStartTemplate\` (use as your base)
 - The \`commonMistakes\` array (avoid these errors)
-- Current pragma format: \`pragma language_version >= 0.16 && <= 0.18;\`
+- Current pragma format: \`pragma language_version >= 0.16 && <= 0.21;\`
 
 ### Step 2: Generate Contract
 Based on syntax reference, generate the contract using:
@@ -272,7 +272,7 @@ ${contractCode}
 Call \`midnight-extract-contract-structure\` with the contract code to check for:
 - deprecated_ledger_block (should use \`export ledger field: Type;\`)
 - invalid_void_type (should use \`[]\` not \`Void\`)
-- invalid_pragma_format (should use \`>= 0.16 && <= 0.18\`)
+- invalid_pragma_format (should use \`>= 0.16 && <= 0.21\`)
 - unexported_enum (enums need \`export\`)
 - deprecated_cell_wrapper
 
@@ -457,7 +457,7 @@ ${contractCode}
 Call \`midnight-extract-contract-structure\` FIRST to check for common syntax errors:
 - deprecated_ledger_block → should use \`export ledger field: Type;\`
 - invalid_void_type → should use \`[]\` not \`Void\`
-- invalid_pragma_format → should use \`>= 0.16 && <= 0.18\`
+- invalid_pragma_format → should use \`>= 0.16 && <= 0.21\`
 - unexported_enum → enums need \`export\` keyword
 
 ### Step 2: Get Correct Syntax

--- a/src/resources/content/code-content.ts
+++ b/src/resources/content/code-content.ts
@@ -7,7 +7,7 @@ export const EMBEDDED_CODE: Record<string, string> = {
   "midnight://code/examples/counter": `// Counter Example Contract
 // A simple contract demonstrating basic Compact concepts
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -57,7 +57,7 @@ export circuit isLessThan(threshold: Uint<64>): Boolean {
   "midnight://code/examples/bboard": `// Bulletin Board Example Contract
 // Demonstrates private messaging with selective disclosure
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -107,7 +107,7 @@ export circuit getMessageCount(): Uint<64> {
   "midnight://code/patterns/state-management": `// State Management Pattern
 // Best practices for managing public and private state
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -159,7 +159,7 @@ export circuit revealBalance(user: Opaque<"address">): Field {
   "midnight://code/patterns/access-control": `// Access Control Pattern
 // Implementing permissions and authorization
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -215,7 +215,7 @@ export circuit timeLockedAction(unlockTime: Field): [] {
   "midnight://code/patterns/privacy-preserving": `// Privacy-Preserving Patterns
 // Techniques for maintaining privacy in smart contracts
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -321,7 +321,7 @@ export circuit proveMembership(
   "midnight://code/templates/token": `// Privacy-Preserving Token Template
 // Starter template for token contracts with privacy features
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -381,7 +381,7 @@ export circuit mint(to: Opaque<"address">, amount: Uint<64>): Boolean {
   "midnight://code/templates/voting": `// Private Voting Template
 // Starter template for privacy-preserving voting contracts
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -462,7 +462,7 @@ export circuit addVoter(voter: Opaque<"address">): [] {
   "midnight://code/examples/nullifier": `// Nullifier Pattern Example
 // Demonstrates how to create and use nullifiers to prevent double-spending/actions
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -530,7 +530,7 @@ export circuit voteWithNullifier(
   "midnight://code/examples/hash": `// Hash Functions in Compact
 // Examples of using hash functions for various purposes
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -578,7 +578,7 @@ export circuit reveal(value: Field, randomness: Field): Field {
   "midnight://code/examples/simple-counter": `// Simple Counter Contract
 // Minimal example for learning Compact basics
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -617,7 +617,7 @@ export circuit reset(): [] {
   "midnight://code/templates/basic": `// Basic Compact Contract Template
 // Starting point for new contracts
 
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 

--- a/src/resources/content/docs-content.ts
+++ b/src/resources/content/docs-content.ts
@@ -12,7 +12,7 @@
  */
 
 export const EMBEDDED_DOCS: Record<string, string> = {
-  "midnight://docs/compact-reference": `# Compact Language Syntax Reference (v0.16 - v0.18)
+  "midnight://docs/compact-reference": `# Compact Language Syntax Reference (v0.16 - v0.21)
 
 > **CRITICAL**: This reference is derived from **actual compiling contracts** in the Midnight ecosystem.
 > Always verify syntax against this reference before generating contracts.
@@ -22,7 +22,7 @@ export const EMBEDDED_DOCS: Record<string, string> = {
 Use this as a starting point - it compiles successfully:
 
 \`\`\`compact
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -45,13 +45,13 @@ export circuit increment(): [] {
 
 **CORRECT** - use bounded range without patch version:
 \`\`\`compact
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 \`\`\`
 
 **WRONG** - these will cause parse errors:
 \`\`\`compact
 pragma language_version >= 0.14.0;           // ❌ patch version not needed
-pragma language_version >= 0.16.0 < 0.19.0;  // ❌ wrong operator format
+pragma language_version >= 0.20.0 < 0.22.0;  // ❌ wrong operator format
 \`\`\`
 
 ---
@@ -299,7 +299,7 @@ export circuit authenticated_action(): [] {
 
 ### Commit-Reveal Pattern (COMPLETE, VALIDATED)
 \`\`\`compact
-pragma language_version >= 0.16 && <= 0.18;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -539,7 +539,7 @@ assert(disclose(caller == owner), "Not authorized");
 |---------|---------|
 | \`ledger { field: Type; }\` | \`export ledger field: Type;\` |
 | \`circuit fn(): Void\` | \`circuit fn(): []\` |
-| \`pragma >= 0.16.0\` | \`pragma >= 0.16 && <= 0.18\` |
+| \`pragma >= 0.20.0\` | \`pragma >= 0.16 && <= 0.21\` |
 | \`enum State { ... }\` | \`export enum State { ... }\` |
 | \`if (witness_val == x)\` | \`if (disclose(witness_val == x))\` |
 | \`Cell<Field>\` | \`Field\` (Cell is deprecated) |
@@ -875,7 +875,7 @@ npm install @openzeppelin/compact-contracts
 ## Usage Example
 
 \`\`\`compact
-pragma language_version >= 0.18.0;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 import "@openzeppelin/compact-contracts/src/token/FungibleToken"
@@ -917,7 +917,7 @@ The recommended standard for privacy-preserving tokens on Midnight.
 ## Basic Usage
 
 \`\`\`compact
-pragma language_version >= 0.18.0;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 import "@openzeppelin/compact-contracts/src/token/FungibleToken"

--- a/src/services/sampling.ts
+++ b/src/services/sampling.ts
@@ -150,7 +150,7 @@ Key Compact syntax (REQUIRED):
 - \`export ledger field: Type;\` - Individual ledger declarations (NOT ledger { } blocks)
 - \`export circuit fn(): []\` - Public functions return empty tuple [] (NOT Void)
 - \`witness fn(): T;\` - Declaration only, no body
-- \`pragma language_version >= 0.16 && <= 0.18;\` - Version pragma
+- \`pragma language_version >= 0.16 && <= 0.21;\` - Version pragma
 - \`import CompactStandardLibrary;\` - Standard imports
 - \`Counter\`, \`Map<K,V>\`, \`Set<T>\` - Built-in collection types  
 - \`Field\`, \`Boolean\`, \`Uint<N>\`, \`Bytes<N>\` - Primitive types

--- a/src/tools/repository/validation.ts
+++ b/src/tools/repository/validation.ts
@@ -594,7 +594,7 @@ export async function extractContractStructure(
       type: "invalid_pragma_format",
       line: lineNum,
       message: `Pragma includes patch version which may cause parse errors`,
-      suggestion: `Use bounded range format: 'pragma language_version >= 0.16 && <= 0.18;'`,
+      suggestion: `Use bounded range format: 'pragma language_version >= 0.16 && <= 0.21;'`,
       severity: "error",
     });
   }

--- a/tests/analyze.test.ts
+++ b/tests/analyze.test.ts
@@ -17,7 +17,7 @@ import {
 describe("Contract Analyzer", () => {
   it("should analyze a simple counter contract", async () => {
     const code = `
-pragma language_version >= 0.18.0;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -154,7 +154,7 @@ describe("Compile Contract", () => {
       json: async () => ({
         success: true,
         output: "Compilation successful",
-        compilerVersion: "0.18.0",
+        compilerVersion: "0.29.0",
         compiledAt: "2026-01-19T19:17:56.064Z",
         executionTime: 2841,
       }),
@@ -162,7 +162,7 @@ describe("Compile Contract", () => {
 
     const result = (await compileContract({
       code: `
-pragma language_version >= 0.18.0;
+pragma language_version >= 0.16 && <= 0.21;
 
 ledger {
   counter: Counter;
@@ -176,7 +176,7 @@ export circuit increment(): Void {
 
     expect(result.success).toBe(true);
     expect(result.message).toContain("Compilation successful");
-    expect(result.compilerVersion).toBe("0.18.0");
+    expect(result.compilerVersion).toBe("0.29.0");
   });
 
   it("should return error details for invalid contract", async () => {
@@ -217,7 +217,7 @@ export circuit increment(): Void {
       json: async () => ({
         success: true,
         output: "Compilation successful",
-        compilerVersion: "0.18.0",
+        compilerVersion: "0.29.0",
         compiledAt: "2026-01-19T19:17:56.064Z",
         executionTime: 2841,
       }),
@@ -225,7 +225,7 @@ export circuit increment(): Void {
 
     const result = (await compileContract({
       code: `
-pragma language_version >= 0.18.0;
+pragma language_version >= 0.16 && <= 0.21;
 
 ledger {
   counter: Counter;
@@ -240,14 +240,14 @@ export circuit increment(): Void {
     expect(result.success).toBe(true);
     expect(result.validationType).toBe("compiler");
     expect(result.message).toContain("Compilation successful");
-    expect(result.compilerVersion).toBe("0.18.0");
+    expect(result.compilerVersion).toBe("0.29.0");
   });
 
   it("should fall back to static analysis on network failures", async () => {
     mockFetch.mockRejectedValueOnce(new Error("Network error"));
 
     const validCode = `
-pragma language_version >= 0.18.0;
+pragma language_version >= 0.16 && <= 0.21;
 
 ledger {
   counter: Counter;
@@ -338,14 +338,14 @@ describe("Compiler Status", () => {
       ok: true,
       json: async () => ({
         status: "ok",
-        compilerVersion: "0.18.0",
+        compilerVersion: "0.29.0",
       }),
     });
 
     const result = (await getCompilerStatus()) as Record<string, unknown>;
 
     expect(result.available).toBe(true);
-    expect(result.compilerVersion).toBe("0.18.0");
+    expect(result.compilerVersion).toBe("0.29.0");
     expect(result.message).toContain("✅");
   });
 

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -57,7 +57,7 @@ witness getSecret(): Field {
 
   it("should parse imports", () => {
     const code = `
-pragma language_version >= 0.18.0;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 import "@openzeppelin/compact-contracts/src/token/FungibleToken"
@@ -78,7 +78,7 @@ ledger {
 
   it("should parse a complete contract", () => {
     const code = `
-pragma language_version >= 0.18.0;
+pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 

--- a/tests/syntax-drift.test.ts
+++ b/tests/syntax-drift.test.ts
@@ -103,7 +103,7 @@ describe("Syntax Drift Detection", () => {
 
   describe("Common Mistakes Detection", () => {
     it("should detect deprecated ledger block syntax", async () => {
-      const badCode = `pragma language_version >= 0.16 && <= 0.18;
+      const badCode = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -125,7 +125,7 @@ ledger {
     });
 
     it("should detect invalid Void return type", async () => {
-      const badCode = `pragma language_version >= 0.16 && <= 0.18;
+      const badCode = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -167,7 +167,7 @@ export ledger counter: Counter;
     });
 
     it("should detect deprecated Cell wrapper", async () => {
-      const badCode = `pragma language_version >= 0.16 && <= 0.18;
+      const badCode = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -186,7 +186,7 @@ export ledger value: Cell<Field>;
     });
 
     it("should detect unexported enum", async () => {
-      const badCode = `pragma language_version >= 0.16 && <= 0.18;
+      const badCode = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -210,7 +210,7 @@ enum State {
 
   describe("CORRECT patterns should NOT trigger errors", () => {
     it("should accept correct pragma format with bounded range", async () => {
-      const goodCode = `pragma language_version >= 0.16 && <= 0.18;
+      const goodCode = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -228,7 +228,7 @@ export ledger counter: Counter;
     });
 
     it("should accept individual ledger declarations", async () => {
-      const goodCode = `pragma language_version >= 0.16 && <= 0.18;
+      const goodCode = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -248,7 +248,7 @@ ledger secretValue: Field;
     });
 
     it("should accept [] return type", async () => {
-      const goodCode = `pragma language_version >= 0.16 && <= 0.18;
+      const goodCode = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -270,7 +270,7 @@ export circuit increment(): [] {
     });
 
     it("should accept exported enum", async () => {
-      const goodCode = `pragma language_version >= 0.16 && <= 0.18;
+      const goodCode = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -325,7 +325,7 @@ export enum State {
   describe("Full Contract Template", () => {
     it("counter contract template should pass static analysis", async () => {
       // A complete counter contract based on the documented patterns
-      const counterContract = `pragma language_version >= 0.16 && <= 0.18;
+      const counterContract = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 
@@ -377,7 +377,7 @@ export circuit get_value(): Uint<64> {
     });
 
     it("token contract template should pass static analysis", async () => {
-      const tokenContract = `pragma language_version >= 0.16 && <= 0.18;
+      const tokenContract = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 

--- a/tests/syntax-validator.test.ts
+++ b/tests/syntax-validator.test.ts
@@ -72,7 +72,7 @@ describe("Syntax Validator Service", () => {
 
   describe("scanForDeprecatedPatterns", () => {
     it("should detect deprecated ledger block syntax", () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 ledger {
   counter: Counter;
@@ -141,7 +141,7 @@ ledger {
     });
 
     it("should include line numbers in issues", () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 import CompactStandardLibrary;
 
 ledger {
@@ -156,7 +156,7 @@ ledger {
     });
 
     it("should return empty array for valid code", () => {
-      const code = `pragma language_version >= 0.16 && <= 0.18;
+      const code = `pragma language_version >= 0.16 && <= 0.21;
 
 import CompactStandardLibrary;
 

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -7,7 +7,7 @@ import { extractContractStructure } from "../src/tools/repository/validation.js"
 describe("Contract Structure Extraction", () => {
   describe("extractContractStructure", () => {
     it("should extract pragma version with >= operator", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 import CompactStandardLibrary;
 
@@ -16,7 +16,7 @@ export ledger counter: Counter;
       const result = await extractContractStructure({ code });
 
       expect(result.success).toBe(true);
-      expect(result.languageVersion).toBe("0.16");
+      expect(result.languageVersion).toBe("0.20");
     });
 
     it("should extract pragma version with > operator", async () => {
@@ -31,25 +31,25 @@ export ledger counter: Counter;
     });
 
     it("should extract pragma version with == operator", async () => {
-      const code = `pragma language_version == 0.16;
+      const code = `pragma language_version == 0.20;
 
 export ledger counter: Counter;
 `;
       const result = await extractContractStructure({ code });
 
       expect(result.success).toBe(true);
-      expect(result.languageVersion).toBe("0.16");
+      expect(result.languageVersion).toBe("0.20");
     });
 
     it("should extract pragma version with ~ operator", async () => {
-      const code = `pragma language_version ~ 0.16;
+      const code = `pragma language_version ~ 0.20;
 
 export ledger counter: Counter;
 `;
       const result = await extractContractStructure({ code });
 
       expect(result.success).toBe(true);
-      expect(result.languageVersion).toBe("0.16");
+      expect(result.languageVersion).toBe("0.20");
     });
 
     it("should extract pragma version with < operator", async () => {
@@ -64,18 +64,18 @@ export ledger counter: Counter;
     });
 
     it("should extract pragma version with <= operator", async () => {
-      const code = `pragma language_version <= 0.16;
+      const code = `pragma language_version <= 0.20;
 
 export ledger counter: Counter;
 `;
       const result = await extractContractStructure({ code });
 
       expect(result.success).toBe(true);
-      expect(result.languageVersion).toBe("0.16");
+      expect(result.languageVersion).toBe("0.20");
     });
 
     it("should extract imports", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 import CompactStandardLibrary;
 include "utils.compact";
@@ -88,7 +88,7 @@ include "utils.compact";
     });
 
     it("should extract circuit definitions", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 export circuit increment(amount: Field): [] {
   counter.increment(amount);
@@ -119,7 +119,7 @@ circuit helper(): Field {
     });
 
     it("should handle complex parameter types with nested generics", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 export circuit transfer(from: Opaque<"address">, to: Opaque<"address">, amounts: Map<Field, Uint<64>>): [Boolean, Field] {
   // implementation
@@ -140,7 +140,7 @@ export circuit transfer(from: Opaque<"address">, to: Opaque<"address">, amounts:
     });
 
     it("should handle function types in parameters", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 export circuit withCallback(fn: (a: Field, b: Field) => Boolean, data: Field): [] {
   // implementation
@@ -161,7 +161,7 @@ export circuit withCallback(fn: (a: Field, b: Field) => Boolean, data: Field): [
     });
 
     it("should handle string literals with commas in parameters", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 export circuit withStringType(addr: Opaque<"a, b">, data: Field): [] {
   // implementation
@@ -182,7 +182,7 @@ export circuit withStringType(addr: Opaque<"a, b">, data: Field): [] {
     });
 
     it("should extract witness definitions", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 export witness getSecret: () => Field;
 witness privateHelper: (x: Field) => Boolean;
@@ -201,7 +201,7 @@ witness privateHelper: (x: Field) => Boolean;
     });
 
     it("should extract ledger items", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 export ledger counter: Counter;
 export ledger balances: Map<Bytes<32>, Uint<64>>;
@@ -218,7 +218,7 @@ ledger privateData: Field;
     });
 
     it("should extract type definitions", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 type Address = Bytes<32>;
 type Balance = Uint<64>;
@@ -233,7 +233,7 @@ type Balance = Uint<64>;
     });
 
     it("should extract struct definitions", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 struct User {
   id: Field,
@@ -251,7 +251,7 @@ struct User {
     });
 
     it("should extract enum definitions", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 enum Status {
   Pending,
@@ -271,7 +271,7 @@ enum Status {
     });
 
     it("should generate accurate statistics", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 import CompactStandardLibrary;
 
@@ -303,7 +303,7 @@ type MyType = Field;
     });
 
     it("should handle empty contract", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 `;
       const result = await extractContractStructure({ code });
 
@@ -328,7 +328,7 @@ type MyType = Field;
 
     it("should reject binary content", async () => {
       const binaryContent =
-        "pragma language_version >= 0.16;\x00\x00binary data";
+        "pragma language_version >= 0.20;\x00\x00binary data";
       const result = await extractContractStructure({ code: binaryContent });
 
       expect(result.success).toBe(false);
@@ -336,7 +336,7 @@ type MyType = Field;
     });
 
     it("should generate summary message", async () => {
-      const code = `pragma language_version >= 0.16;
+      const code = `pragma language_version >= 0.20;
 
 export ledger counter: Counter;
 export circuit increment(): [] {}
@@ -388,7 +388,7 @@ describe("Standard Library Detection", () => {
   // These tests verify the word boundary detection for stdlib types
 
   it("should detect Counter type usage", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 export ledger counter: Counter;
 `;
     const result = await extractContractStructure({ code });
@@ -399,7 +399,7 @@ export ledger counter: Counter;
   });
 
   it("should detect Map type usage", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 export ledger data: Map<Field, Field>;
 `;
     const result = await extractContractStructure({ code });
@@ -412,7 +412,7 @@ export ledger data: Map<Field, Field>;
 
 describe("Pre-compilation Issue Detection", () => {
   it("should detect module-level const declarations", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 const MAX_VALUE: Uint<128> = 1000;
 
@@ -432,7 +432,7 @@ export circuit getValue(): Uint<128> {
   });
 
   it("should detect stdlib name collisions", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 import CompactStandardLibrary;
 
@@ -456,7 +456,7 @@ pure circuit burnAddress(): ZswapCoinPublicKey {
   });
 
   it("should detect sealed + export conflicts", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 sealed ledger tokenName: Bytes<32>;
 
@@ -481,7 +481,7 @@ export circuit initialize(name: Bytes<32>): [] {
   });
 
   it("should not flag const inside circuit blocks", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 export circuit getValue(): Uint<128> {
   const MAX_VALUE: Uint<128> = 1000;
@@ -500,7 +500,7 @@ export circuit getValue(): Uint<128> {
   });
 
   it("should not flag stdlib collision when no import", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 pure circuit burnAddress(): ZswapCoinPublicKey {
   return default<ZswapCoinPublicKey>;
@@ -518,7 +518,7 @@ pure circuit burnAddress(): ZswapCoinPublicKey {
   });
 
   it("should warn about missing constructor with sealed fields", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 sealed ledger tokenName: Bytes<32>;
 
@@ -537,7 +537,7 @@ export circuit initialize(name: Bytes<32>): [] {
   });
 
   it("should include issue count in message", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 const BAD_CONST: Field = 42;
 
@@ -553,7 +553,7 @@ export circuit test(): Field {
   });
 
   it("should detect division operator usage", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 export circuit divide(a: Uint<64>, b: Uint<64>): Uint<64> {
   return a / b;
@@ -576,7 +576,7 @@ export circuit divide(a: Uint<64>, b: Uint<64>): Uint<64> {
   });
 
   it("should detect Counter.value() access and suggest .read()", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 ledger gameCount: Counter;
 
@@ -601,7 +601,7 @@ export circuit getCount(): Uint<64> {
   });
 
   it("should warn about potential Uint overflow in multiplication", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 witness getQuotient(dividend: Uint<64>, divisor: Uint<64>): Uint<64>;
 
@@ -625,7 +625,7 @@ export circuit verifyDivision(dividend: Uint<64>, divisor: Uint<64>): [] {
   });
 
   it("should warn about undisclosed witness in conditional", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 witness secret: Uint<64>;
 
@@ -652,7 +652,7 @@ export circuit checkSecret(expected: Uint<64>): [] {
   });
 
   it("should not flag division in comments", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 // This is a comment about a / b division
 export circuit add(a: Uint<64>, b: Uint<64>): Uint<64> {
@@ -670,7 +670,7 @@ export circuit add(a: Uint<64>, b: Uint<64>): Uint<64> {
   });
 
   it("should detect constructor params assigned to ledger without disclose", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 sealed ledger tokenName: Bytes<32>;
 sealed ledger tokenSymbol: Bytes<8>;
@@ -698,7 +698,7 @@ constructor(name: Bytes<32>, symbol: Bytes<8>) {
   });
 
   it("should not flag constructor params when disclose is used", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 sealed ledger tokenName: Bytes<32>;
 sealed ledger tokenSymbol: Bytes<8>;
@@ -720,7 +720,7 @@ constructor(name: Bytes<32>, symbol: Bytes<8>) {
   });
 
   it("should detect if expression used in assignment", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 ledger balances: Map<Bytes<32>, Uint<128>>;
 
@@ -748,7 +748,7 @@ export circuit getBalance(addr: Bytes<32>): Uint<128> {
   });
 
   it("should detect Void return type", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 export circuit doSomething(): Void {
   // some code
@@ -769,7 +769,7 @@ export circuit doSomething(): Void {
   });
 
   it("should not flag valid empty tuple return type", async () => {
-    const code = `pragma language_version >= 0.16;
+    const code = `pragma language_version >= 0.20;
 
 export circuit doSomething(): [] {
   // some code


### PR DESCRIPTION
- Update COMPACT_VERSION max from 0.18 to 0.21 (compiler 0.29.0) with min of 16
- Add new-style ledger declaration parsing (export ledger name: Type;) alongside legacy block-style detection in parser.ts
- Update all pragma examples, prompt templates, validation suggestions, and embedded docs to use >= 0.16 && <= 0.21
- Update tests and documentation to match new version range

Closes issue: hosted compiler language version 0.18.0 mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for single-line ledger field declarations with optional `export` prefix.

* **Documentation**
  * Updated supported Compact language version range from v0.16–0.18 to v0.16–0.21.
  * Updated compiler version references from v0.18.0 to v0.29.0 across documentation.
  * Enhanced offline syntax guidance and code examples to reflect new version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes: #35 