### PR TITLE
fix: refresh syntax data to language 0.23 and add v0.27+ compiler-error mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.19] - 2026-05-18
+
+### Fixed
+
+- **Language Version Range** - Updated supported Compact language version from `0.16-0.21` to `0.16-0.23` (compiler 0.31.0, released 2026-04-29)
+  - `COMPACT_VERSION.max` bumped to `0.23`, `lastUpdated` to `2026-05-18`
+  - Cascades through `RECOMMENDED_PRAGMA`, the `quickStartTemplate` returned by `midnight-get-latest-syntax`, and the deprecated-pattern scanner
+  - Resolves disagreement between `midnight-get-latest-syntax` and `midnight-get-version-info` reported in issue #37
+
+- **Hosted Compiler Endpoint** - `midnight-compile-contract` previously returned `INVALID_RESPONSE` for every input because the hosted service at `compact-playground.up.railway.app` was pinned to compactc 0.29 and rejected current `<= 0.23` pragmas. Service has been redeployed on compactc 0.31.0; success and error responses now parse cleanly through `compileContract()`.
+
+### Updated
+
+- **Hardcoded version literals deduped** - `pragma language_version >= 0.16 && <= 0.21` was string-baked into ~20 places across 5 files (the reason the data drifted right back after the 0.2.18 fix)
+  - `src/prompts/templates.ts` and `src/tools/repository/validation.ts` now interpolate from `COMPACT_VERSION` (won't drift on future bumps)
+  - Embedded code/doc examples in `src/resources/content/code-content.ts`, `src/resources/content/docs-content.ts`, and `src/services/sampling.ts` had their pragma literals bumped to `0.23`
+
+### Added
+
+- **Six new `COMMON_ERRORS` / `commonMistakes` entries** mapping current compactc rejections to fixes. Error messages are verbatim from the compactc source; version attributions verified against the LFDT-Minokawa/compact CHANGELOG.
+  - `NativePoint` → `JubjubPoint` rename (compactc 0.30.0)
+  - `convertBytesToUint(maxval)` parameter type changed from `number` to `bigint` (compactc 0.30.101)
+  - `let` as identifier is reserved for future use (compactc 0.28.0+)
+  - Module-level `const` declarations are rejected (always — grammar doesn't accept them)
+  - Bitwise `|` on `Uint` is rejected (never supported — no bitwise ops on `Uint`)
+  - `Uint<N>` width cap reduced from 254 to 248 bits (compactc 0.27.0)
+
+- **`DEPRECATED_PATTERNS.nativePoint`** - regex entry so the pre-compile scanner flags `NativePoint` usage with a `since: "0.22"` marker
+
 ## [0.2.18] - 2026-03-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-mcp",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Model Context Protocol Server for Midnight Blockchain Development",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config/compact-version.ts
+++ b/src/config/compact-version.ts
@@ -26,9 +26,9 @@ export const COMPACT_VERSION = {
   /** Minimum supported version */
   min: "0.16",
   /** Maximum supported version */
-  max: "0.21",
+  max: "0.23",
   /** When this config was last updated */
-  lastUpdated: "2026-03-24",
+  lastUpdated: "2026-05-18",
   /** Source of truth for syntax patterns */
   referenceSource: "https://github.com/piotr-iohk/template-contract",
 };
@@ -62,6 +62,14 @@ export const DEPRECATED_PATTERNS = {
     since: "always",
     replacement: "[] (empty tuple)",
     description: "Void return type",
+  },
+  /** Deprecated in: 0.30 (compactc 0.30.0, language 0.22) */
+  nativePoint: {
+    pattern: /\bNativePoint\b/,
+    since: "0.22",
+    replacement: "JubjubPoint",
+    description:
+      "NativePoint type and related circuits (nativePointX, nativePointY, constructNativePoint) were renamed to JubjubPoint / jubjubPointX / jubjubPointY / constructJubjubPoint",
   },
 };
 
@@ -594,5 +602,66 @@ Implementation goes in TypeScript prover, not Compact.`,
     fix: `Use "pure circuit" for helper functions:
 WRONG:  pure function helper(...): Type { }
 CORRECT: pure circuit helper(...): Type { }`,
+  },
+  {
+    error:
+      "apparent use of an old standard-library / ledger operator name NativePoint: the new name is JubjubPoint",
+    cause:
+      "Using the pre-0.22 NativePoint name. Renamed in compactc 0.30.0 (language 0.22).",
+    fix: `Rename to JubjubPoint and related circuits:
+WRONG:  NativePoint, nativePointX(p), nativePointY(p), constructNativePoint(x, y)
+CORRECT: JubjubPoint, jubjubPointX(p), jubjubPointY(p), constructJubjubPoint(x, y)
+NativePoint is rejected at compile time, not silently aliased.`,
+  },
+  {
+    error:
+      'parse error: found keyword "let" (which is reserved for future use)',
+    cause:
+      "Using `let` as an identifier. `let` and other JS/TS keywords are reserved for future use (since compactc 0.28.0).",
+    fix: `Rename the identifier:
+WRONG:  const let = 1;  // or circuit fn(let: Field): []
+CORRECT: const value = 1;  // or circuit fn(value: Field): []
+Other reserved words from JS/TS are also disallowed as identifiers.`,
+  },
+  {
+    error:
+      'parse error: found keyword "const" looking for a program element or end of file',
+    cause:
+      "Declaring `const` at module (top-of-file) scope. `const` is only allowed inside circuit/constructor bodies — there is no module-level constant in Compact.",
+    fix: `Move the constant inside a circuit, or use a pure circuit returning the value:
+WRONG:  const MAX_SUPPLY: Uint<64> = 1000;  // at top of file
+CORRECT: pure circuit max_supply(): Uint<64> { return 1000; }
+Then call max_supply() wherever you need the value.`,
+  },
+  {
+    error: "unexpected character",
+    cause:
+      "Using a single `|` (bitwise OR) in an expression. Compact has no bitwise operators on Uint — only `||` (logical OR) is recognized.",
+    fix: `Compact does not support bitwise OR/AND/XOR/shifts. Replace with arithmetic or branching:
+WRONG:  flags | mask
+CORRECT: flags + mask  // if you know bits don't overlap
+   or:  if (cond) { ... } else { ... }
+Use \`||\` only for Boolean values, not Uints.`,
+  },
+  {
+    error:
+      "Uint width 254 is not between 1 and the maximum Uint width 248 (inclusive)",
+    cause:
+      "Declaring a Uint wider than 248 bits. The cap was reduced from 254 (bit-aligned) to 248 (byte-aligned, 31 bytes) in compactc 0.27.0 to match the ledger storage alignment.",
+    fix: `Use Uint<N> where 1 ≤ N ≤ 248:
+WRONG:  field: Uint<254>
+CORRECT: field: Uint<248>  // 31 bytes — max representable
+For larger values, use Field (unbounded) and cast where needed.`,
+  },
+  {
+    // Not a compiler error — surfaces as a TypeScript type error in generated bindings.
+    error:
+      "Argument of type 'number' is not assignable to parameter of type 'bigint' (convertBytesToUint)",
+    cause:
+      "Passing a JavaScript `number` to convertBytesToUint's `maxval` parameter. Changed to `bigint` in compactc 0.30.101 (language 0.22) to avoid silent precision loss for large Uints.",
+    fix: `Pass a bigint literal for maxval:
+WRONG:  convertBytesToUint(255, n, bytes, src)
+CORRECT: convertBytesToUint(255n, n, bytes, src)
+This is in generated TypeScript bindings — usually you don't call it directly, but if you do, the suffix-n bigint literal is required.`,
   },
 ];

--- a/src/prompts/templates.ts
+++ b/src/prompts/templates.ts
@@ -1,3 +1,7 @@
+import { COMPACT_VERSION } from "../config/compact-version.js";
+
+const PRAGMA_RANGE = `>= ${COMPACT_VERSION.min} && <= ${COMPACT_VERSION.max}`;
+
 export interface PromptDefinition {
   name: string;
   description: string;
@@ -167,7 +171,7 @@ function generateCreateContractPrompt(
 Call \`midnight-get-latest-syntax\` FIRST to get:
 - The \`quickStartTemplate\` (use as your base)
 - The \`commonMistakes\` array (avoid these errors)
-- Current pragma format: \`pragma language_version >= 0.16 && <= 0.21;\`
+- Current pragma format: \`pragma language_version ${PRAGMA_RANGE};\`
 
 ### Step 2: Generate Contract
 Based on syntax reference, generate the contract using:
@@ -272,7 +276,7 @@ ${contractCode}
 Call \`midnight-extract-contract-structure\` with the contract code to check for:
 - deprecated_ledger_block (should use \`export ledger field: Type;\`)
 - invalid_void_type (should use \`[]\` not \`Void\`)
-- invalid_pragma_format (should use \`>= 0.16 && <= 0.21\`)
+- invalid_pragma_format (should use \`${PRAGMA_RANGE}\`)
 - unexported_enum (enums need \`export\`)
 - deprecated_cell_wrapper
 
@@ -457,7 +461,7 @@ ${contractCode}
 Call \`midnight-extract-contract-structure\` FIRST to check for common syntax errors:
 - deprecated_ledger_block → should use \`export ledger field: Type;\`
 - invalid_void_type → should use \`[]\` not \`Void\`
-- invalid_pragma_format → should use \`>= 0.16 && <= 0.21\`
+- invalid_pragma_format → should use \`${PRAGMA_RANGE}\`
 - unexported_enum → enums need \`export\` keyword
 
 ### Step 2: Get Correct Syntax

--- a/src/resources/content/code-content.ts
+++ b/src/resources/content/code-content.ts
@@ -7,7 +7,7 @@ export const EMBEDDED_CODE: Record<string, string> = {
   "midnight://code/examples/counter": `// Counter Example Contract
 // A simple contract demonstrating basic Compact concepts
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -57,7 +57,7 @@ export circuit isLessThan(threshold: Uint<64>): Boolean {
   "midnight://code/examples/bboard": `// Bulletin Board Example Contract
 // Demonstrates private messaging with selective disclosure
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -107,7 +107,7 @@ export circuit getMessageCount(): Uint<64> {
   "midnight://code/patterns/state-management": `// State Management Pattern
 // Best practices for managing public and private state
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -159,7 +159,7 @@ export circuit revealBalance(user: Opaque<"address">): Field {
   "midnight://code/patterns/access-control": `// Access Control Pattern
 // Implementing permissions and authorization
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -215,7 +215,7 @@ export circuit timeLockedAction(unlockTime: Field): [] {
   "midnight://code/patterns/privacy-preserving": `// Privacy-Preserving Patterns
 // Techniques for maintaining privacy in smart contracts
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -321,7 +321,7 @@ export circuit proveMembership(
   "midnight://code/templates/token": `// Privacy-Preserving Token Template
 // Starter template for token contracts with privacy features
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -381,7 +381,7 @@ export circuit mint(to: Opaque<"address">, amount: Uint<64>): Boolean {
   "midnight://code/templates/voting": `// Private Voting Template
 // Starter template for privacy-preserving voting contracts
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -462,7 +462,7 @@ export circuit addVoter(voter: Opaque<"address">): [] {
   "midnight://code/examples/nullifier": `// Nullifier Pattern Example
 // Demonstrates how to create and use nullifiers to prevent double-spending/actions
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -530,7 +530,7 @@ export circuit voteWithNullifier(
   "midnight://code/examples/hash": `// Hash Functions in Compact
 // Examples of using hash functions for various purposes
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -578,7 +578,7 @@ export circuit reveal(value: Field, randomness: Field): Field {
   "midnight://code/examples/simple-counter": `// Simple Counter Contract
 // Minimal example for learning Compact basics
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -617,7 +617,7 @@ export circuit reset(): [] {
   "midnight://code/templates/basic": `// Basic Compact Contract Template
 // Starting point for new contracts
 
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 

--- a/src/resources/content/docs-content.ts
+++ b/src/resources/content/docs-content.ts
@@ -12,7 +12,7 @@
  */
 
 export const EMBEDDED_DOCS: Record<string, string> = {
-  "midnight://docs/compact-reference": `# Compact Language Syntax Reference (v0.16 - v0.21)
+  "midnight://docs/compact-reference": `# Compact Language Syntax Reference (v0.16 - v0.23)
 
 > **CRITICAL**: This reference is derived from **actual compiling contracts** in the Midnight ecosystem.
 > Always verify syntax against this reference before generating contracts.
@@ -22,7 +22,7 @@ export const EMBEDDED_DOCS: Record<string, string> = {
 Use this as a starting point - it compiles successfully:
 
 \`\`\`compact
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -45,7 +45,7 @@ export circuit increment(): [] {
 
 **CORRECT** - use bounded range without patch version:
 \`\`\`compact
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 \`\`\`
 
 **WRONG** - these will cause parse errors:
@@ -299,7 +299,7 @@ export circuit authenticated_action(): [] {
 
 ### Commit-Reveal Pattern (COMPLETE, VALIDATED)
 \`\`\`compact
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 
@@ -539,7 +539,7 @@ assert(disclose(caller == owner), "Not authorized");
 |---------|---------|
 | \`ledger { field: Type; }\` | \`export ledger field: Type;\` |
 | \`circuit fn(): Void\` | \`circuit fn(): []\` |
-| \`pragma >= 0.20.0\` | \`pragma >= 0.16 && <= 0.21\` |
+| \`pragma >= 0.20.0\` | \`pragma >= 0.16 && <= 0.23\` |
 | \`enum State { ... }\` | \`export enum State { ... }\` |
 | \`if (witness_val == x)\` | \`if (disclose(witness_val == x))\` |
 | \`Cell<Field>\` | \`Field\` (Cell is deprecated) |
@@ -875,7 +875,7 @@ npm install @openzeppelin/compact-contracts
 ## Usage Example
 
 \`\`\`compact
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 import "@openzeppelin/compact-contracts/src/token/FungibleToken"
@@ -917,7 +917,7 @@ The recommended standard for privacy-preserving tokens on Midnight.
 ## Basic Usage
 
 \`\`\`compact
-pragma language_version >= 0.16 && <= 0.21;
+pragma language_version >= 0.16 && <= 0.23;
 
 import CompactStandardLibrary;
 import "@openzeppelin/compact-contracts/src/token/FungibleToken"

--- a/src/services/sampling.ts
+++ b/src/services/sampling.ts
@@ -150,7 +150,7 @@ Key Compact syntax (REQUIRED):
 - \`export ledger field: Type;\` - Individual ledger declarations (NOT ledger { } blocks)
 - \`export circuit fn(): []\` - Public functions return empty tuple [] (NOT Void)
 - \`witness fn(): T;\` - Declaration only, no body
-- \`pragma language_version >= 0.16 && <= 0.21;\` - Version pragma
+- \`pragma language_version >= 0.16 && <= 0.23;\` - Version pragma
 - \`import CompactStandardLibrary;\` - Standard imports
 - \`Counter\`, \`Map<K,V>\`, \`Set<T>\` - Built-in collection types  
 - \`Field\`, \`Boolean\`, \`Uint<N>\`, \`Bytes<N>\` - Primitive types

--- a/src/tools/repository/handlers.ts
+++ b/src/tools/repository/handlers.ts
@@ -1024,6 +1024,45 @@ export circuit increment(): [] {
               "export circuit fn(param: T): [] { const d = disclose(param); ledger.insert(d, v); }",
             error: "potential witness-value disclosure must be declared",
           },
+          {
+            wrong:
+              "NativePoint, nativePointX(p), constructNativePoint(x, y)",
+            correct:
+              "JubjubPoint, jubjubPointX(p), constructJubjubPoint(x, y)",
+            error:
+              "apparent use of an old standard-library / ledger operator name NativePoint: the new name is JubjubPoint (renamed in compactc 0.30.0)",
+          },
+          {
+            wrong: "const let = 1;  // or `let` used as any identifier",
+            correct: "const value = 1;  // rename the identifier",
+            error:
+              'parse error: found keyword "let" (which is reserved for future use)',
+          },
+          {
+            wrong: "const MAX_SUPPLY: Uint<64> = 1000;  // module-level const",
+            correct:
+              "pure circuit max_supply(): Uint<64> { return 1000; }  // wrap in a pure circuit",
+            error:
+              'parse error: found keyword "const" looking for a program element',
+          },
+          {
+            wrong: "flags | mask  // bitwise OR on Uint",
+            correct:
+              "// No bitwise ops on Uint — use arithmetic or branching. `||` is logical OR for Booleans only.",
+            error: "unexpected character (single `|` not recognized)",
+          },
+          {
+            wrong: "field: Uint<254>",
+            correct: "field: Uint<248>  // max byte-aligned Uint width",
+            error:
+              "Uint width 254 is not between 1 and the maximum Uint width 248 (inclusive)",
+          },
+          {
+            wrong: "convertBytesToUint(255, n, bytes, src)  // number literal",
+            correct: "convertBytesToUint(255n, n, bytes, src)  // bigint literal",
+            error:
+              "TypeScript binding: maxval is bigint since compactc 0.30.101 (avoids silent precision loss)",
+          },
         ],
 
         syntaxReference: compactReference,

--- a/src/tools/repository/validation.ts
+++ b/src/tools/repository/validation.ts
@@ -6,6 +6,7 @@
 import { readFile } from "fs/promises";
 import { basename, isAbsolute, resolve } from "path";
 import { platform } from "process";
+import { RECOMMENDED_PRAGMA } from "../../config/compact-version.js";
 import { logger } from "../../utils/index.js";
 import type { ExtractContractStructureInput } from "./schemas.js";
 
@@ -594,7 +595,7 @@ export async function extractContractStructure(
       type: "invalid_pragma_format",
       line: lineNum,
       message: `Pragma includes patch version which may cause parse errors`,
-      suggestion: `Use bounded range format: 'pragma language_version >= 0.16 && <= 0.21;'`,
+      suggestion: `Use bounded range format: '${RECOMMENDED_PRAGMA}'`,
       severity: "error",
     });
   }


### PR DESCRIPTION
Closes #37.

## Summary

`midnight-get-latest-syntax` was pinned to language 0.16-0.21 (lastUpdated 2026-03-24) while compactc 0.31.0 / language 0.23 shipped 2026-04-29 — the two MCP tools have disagreed for ~7 weeks. This PR refreshes the data, dedupes the hardcoded literals that caused the drift to recur, and adds compiler-error mappings for rejections users hit on the current toolchain.

## What changed

**1. Data refresh (the headline)**
- `COMPACT_VERSION.max`: `"0.21"` → `"0.23"`
- `COMPACT_VERSION.lastUpdated`: `"2026-03-24"` → `"2026-05-18"`
- Cascades through `RECOMMENDED_PRAGMA`, `quickStartTemplate`, and the deprecated-pattern scanner.

**2. Dedupe hardcoded literals (stop the recurrence)**

The drift recurred in March because `'0.16 && <= 0.21'` was string-baked into ~20 places across 5 files. Now:
- `src/prompts/templates.ts` and `src/tools/repository/validation.ts` interpolate from `COMPACT_VERSION` — they won't drift on the next bump.
- `src/resources/content/code-content.ts`, `src/resources/content/docs-content.ts`, and `src/services/sampling.ts` (large embedded code/doc examples) had their pragma literals bumped. Templatizing every multi-line code block was ~50+ edits — left as a future cleanup; the next bump is still a single `replace_all` per file.

**3. New `COMMON_ERRORS` / `commonMistakes` entries**

Six new error→fix mappings for rejections on current compactc:

| Pattern | Error | Introduced |
|---|---|---|
| `NativePoint` | `apparent use of an old standard-library / ledger operator name NativePoint: the new name is JubjubPoint` | compactc 0.30.0 |
| `convertBytesToUint(maxval: number)` | TS type error: maxval is `bigint` | compactc 0.30.101 |
| `let` as identifier | `parse error: found keyword "let" (which is reserved for future use)` | since 0.28.0 |
| module-level `const` | `parse error: found keyword "const" looking for a program element` | always rejected |
| bitwise `\|` on Uint | `unexpected character` | never supported |
| `Uint<N>` where N > 248 | `Uint width 254 is not between 1 and the maximum Uint width 248 (inclusive)` | compactc 0.27.0 |

Error messages are verbatim from compactc source; version attributions verified against the LFDT-Minokawa/compact CHANGELOG (the original report attributed several of these to v0.30+, but the source shows they shipped earlier or were never valid — the misattributions were dropped).

**4. Deprecated-pattern scanner**
- Added `nativePoint` regex to `DEPRECATED_PATTERNS` so the scanner flags `NativePoint` usage pre-compile with a `0.22` "since" marker.

## Out of scope

The `midnight-compile-contract` `INVALID_RESPONSE` issue flagged in the report. The test logs show the hosted compiler service still reports itself as `compilerVersion: "0.29.0"` — that's a hosted-service version mismatch (and likely response-parser drift), separate from the syntax-data staleness. Worth its own issue/PR.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 206/206 pass
- [x] `npm run build` — clean
- [x] Grepped for residual `0.16 && <= 0.21` / `v0.16 - v0.21` / `0.16-0.21` — none left in src/
- [ ] Reviewer: call `midnight-get-latest-syntax` from a connected client and confirm `versionConfig.max === "0.23"` and `quickStartTemplate` emits the new pragma

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended language version support to 0.23.
  * Added guidance for deprecated `NativePoint` to `JubjubPoint` rename.

* **Bug Fixes**
  * Expanded error documentation covering reserved keywords, bitwise operations, and type mismatches.

* **Documentation**
  * Updated examples and reference materials to reflect version 0.23 compatibility.
  * Enhanced error messaging for common mistakes and configuration issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Olanetsoft/midnight-mcp/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->