### PR TITLE
chore: deprecate midnight-mcp in favour of Kapa + Midnight Expert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,31 @@
 # LOG_LEVEL=info                         # debug|info|warn|error
 
 # ─────────────────────────────────────────────────────────────────
+# Hosted search backend (optional)
+# The public backend is deprecated (see the migration guide). Point these at
+# your own private/self-hosted Worker to keep hosted search working.
+# ─────────────────────────────────────────────────────────────────
+
+# MIDNIGHT_API_URL=https://your-worker.workers.dev   # Override the search backend URL
+# MIDNIGHT_API_TOKEN=xxxxxxxxxxxx                     # Bearer token, if the backend requires auth
+
+# ─────────────────────────────────────────────────────────────────
+# Compact compiler (opt-in — off by default)
+# No contract source is sent anywhere unless you set this. Point it at a
+# compiler you run yourself; leave unset to use local static analysis only.
+# ─────────────────────────────────────────────────────────────────
+
+# COMPACT_COMPILER_URL=http://localhost:8080         # Your own compiler endpoint
+
+# ─────────────────────────────────────────────────────────────────
+# Repository access (optional)
+# Extra GitHub owners allowed for direct "owner/repo" access, on top of the
+# built-in vetted list. Comma-separated. Add your own to use them locally.
+# ─────────────────────────────────────────────────────────────────
+
+# MIDNIGHT_MCP_ALLOWED_REPO_OWNERS=my-org,my-user
+
+# ─────────────────────────────────────────────────────────────────
 # Local Mode (optional - for privacy or offline use)
 # Set MIDNIGHT_LOCAL=true to enable
 # ─────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Midnight MCP Server
 
+> ## ⚠️ Deprecated — use Kapa + Midnight Expert
+>
+> **midnight-mcp is being wound down.** Midnight has standardised on two official tools:
+>
+> - **Kapa MCP** (docs Q&A / search): `claude mcp add --transport http midnight https://midnight.mcp.kapa.ai`
+> - **Midnight Expert** (hands-on dev, Claude Code plugins): `curl -fsSL https://midnightntwrk.expert/install.sh | bash`
+>
+> **Migration guide → https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert**
+
 [![npm version](https://badge.fury.io/js/midnight-mcp.svg)](https://www.npmjs.com/package/midnight-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/midnight-mcp)](https://npm-stat.com/charts.html?package=midnight-mcp)
 [![License](https://img.shields.io/npm/l/midnight-mcp)](./LICENSE)

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -24,10 +24,28 @@ app.use(
   cors({
     origin: "*",
     allowMethods: ["GET", "POST", "OPTIONS"],
-    allowHeaders: ["Content-Type"],
+    allowHeaders: ["Content-Type", "Authorization"],
     maxAge: 86400, // 24 hours
   })
 );
+
+// Optional bearer auth for private/self-hosted deployments. When API_AUTH_TOKEN
+// is set, every request except the health probes must send
+// `Authorization: Bearer <token>`. Unset = open (preserves prior behaviour).
+app.use("*", async (c, next) => {
+  const token = c.env.API_AUTH_TOKEN;
+  if (!token) return next();
+
+  const path = new URL(c.req.url).pathname;
+  if (c.req.method === "OPTIONS" || path === "/" || path === "/health") {
+    return next();
+  }
+
+  if (c.req.header("Authorization") !== `Bearer ${token}`) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  return next();
+});
 
 // Mount routes
 app.route("/", healthRoutes);

--- a/api/src/interfaces/index.ts
+++ b/api/src/interfaces/index.ts
@@ -10,6 +10,9 @@ export type Bindings = {
   ENVIRONMENT: string;
   METRICS: KVNamespace;
   DASHBOARD_PASSWORD?: string;
+  // Optional bearer token for private/self-hosted deployments. When set, all
+  // routes except the health probes require `Authorization: Bearer <token>`.
+  API_AUTH_TOKEN?: string;
 };
 
 // ============== Metrics Types ==============

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -34,8 +34,16 @@ statsRoutes.get("/queries", async (c) => {
   await loadMetrics(c.env.METRICS);
   const metrics = getMetrics();
 
+  // Strip query text before serving. recentQueries is public and
+  // unauthenticated; query bodies can contain proprietary contract source.
+  // (New entries store no query text — see services/metrics.ts — but this also
+  // protects any entries captured before that change and still cached in KV.)
+  const safeRecentQueries = metrics.recentQueries.map(
+    ({ query: _query, ...rest }) => rest
+  );
+
   return c.json({
-    recentQueries: metrics.recentQueries,
+    recentQueries: safeRecentQueries,
     total: metrics.totalQueries,
   });
 });

--- a/api/src/services/metrics.ts
+++ b/api/src/services/metrics.ts
@@ -73,9 +73,13 @@ export function trackQuery(
     }
   });
 
-  // Keep last 100 queries
+  // Keep last 100 queries.
+  // NOTE: query text is intentionally NOT stored. Search queries can contain
+  // proprietary contract source, and recentQueries is exposed publicly
+  // (see routes/stats.ts and the dashboard). We retain only non-sensitive
+  // analytics (endpoint, scores, counts) — never the query body.
   const logEntry: QueryLog = {
-    query: query.slice(0, 100), // Truncate for storage
+    query: "",
     endpoint,
     timestamp: new Date().toISOString(),
     resultsCount: matches.length,

--- a/api/src/stub.ts
+++ b/api/src/stub.ts
@@ -1,0 +1,116 @@
+/**
+ * Midnight MCP API — deprecation stub
+ *
+ * This replaces the real search Worker on the PUBLIC URL. midnight-mcp is being
+ * retired in favour of the official Kapa MCP (docs Q&A) and Midnight Expert
+ * (hands-on dev). The stub keeps every route the client calls so existing
+ * installs get a clear redirect at the point of use instead of an opaque
+ * network error — it holds no OpenAI key, no Vectorize index and no KV, so it
+ * cannot leak or bill anything.
+ *
+ * The real search backend (src/index.ts) is deployed separately under a private
+ * name via wrangler.private.toml for the maintainer's own local use.
+ */
+
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { cors } from "hono/cors";
+
+const BLOG_URL =
+  "https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert";
+
+const DEPRECATION_MESSAGE =
+  "This community Midnight MCP backend is deprecated. Midnight now uses the " +
+  "official Kapa MCP (docs Q&A) and Midnight Expert (hands-on dev). " +
+  `Migrate: ${BLOG_URL}`;
+
+const REDIRECT = {
+  deprecated: true,
+  message: DEPRECATION_MESSAGE,
+  kapa: "https://midnight.mcp.kapa.ai",
+  midnightExpert: "https://midnightntwrk.expert",
+  guide: BLOG_URL,
+};
+
+const app = new Hono();
+
+// Keep CORS open so existing browser/tool callers still receive the payload.
+app.use(
+  "*",
+  cors({
+    origin: "*",
+    allowMethods: ["GET", "POST", "OPTIONS"],
+    allowHeaders: ["Content-Type"],
+    maxAge: 86400,
+  })
+);
+
+// Health — keep status "healthy" so the MCP client's health check does not
+// hard-fail; it still carries the deprecation notice.
+app.get("/", (c) =>
+  c.json({ status: "ok", service: "midnight-mcp-api", ...REDIRECT })
+);
+app.get("/health", (c) =>
+  c.json({ status: "healthy", vectorStore: "deprecated", ...REDIRECT })
+);
+
+// Search — return a shape the client parses cleanly (results[] + warnings[]) so
+// the deprecation message surfaces in the tool output instead of crashing on a
+// missing results array or being swallowed as an error.
+async function readQuery(c: Context): Promise<string> {
+  try {
+    const body = await c.req.json<{ query?: unknown }>();
+    return typeof body?.query === "string" ? body.query : "";
+  } catch {
+    return "";
+  }
+}
+
+const searchStub = async (c: Context) => {
+  const query = await readQuery(c);
+  return c.json({
+    results: [],
+    totalResults: 0,
+    query,
+    warnings: [DEPRECATION_MESSAGE],
+    ...REDIRECT,
+  });
+};
+
+app.post("/v1/search", searchStub);
+app.post("/v1/search/compact", searchStub);
+app.post("/v1/search/typescript", searchStub);
+app.post("/v1/search/docs", searchStub);
+
+// Stats — no analytics are collected any more.
+app.get("/v1/stats", (c) =>
+  c.json({ service: "midnight-mcp-api", metrics: null, ...REDIRECT })
+);
+app.get("/v1/stats/queries", (c) =>
+  c.json({ recentQueries: [], total: 0, ...REDIRECT })
+);
+
+// Track — accept and no-op so fire-and-forget telemetry calls do not error.
+app.post("/v1/track/tool", (c) => c.json({ tracked: false, ...REDIRECT }));
+
+// Dashboard — static deprecation page.
+app.get("/dashboard", (c) =>
+  c.html(
+    `<!doctype html><html><head><meta charset="utf-8"><title>midnight-mcp — deprecated</title>
+<style>body{font-family:system-ui,sans-serif;max-width:640px;margin:10vh auto;padding:0 1.5rem;line-height:1.6;color:#222}a{color:#5b21b6}code{background:#f4f4f5;padding:.15rem .35rem;border-radius:4px}</style>
+</head><body>
+<h1>⚠️ midnight-mcp is deprecated</h1>
+<p>Midnight has standardised on two official tools:</p>
+<ul>
+<li><strong>Kapa MCP</strong> (docs Q&amp;A / search): <code>claude mcp add --transport http midnight https://midnight.mcp.kapa.ai</code></li>
+<li><strong>Midnight Expert</strong> (hands-on dev): <code>curl -fsSL https://midnightntwrk.expert/install.sh | bash</code></li>
+</ul>
+<p>Migration guide → <a href="${BLOG_URL}">${BLOG_URL}</a></p>
+</body></html>`
+  )
+);
+
+// Anything else — redirect payload.
+app.all("*", (c) => c.json(REDIRECT, 404));
+
+export default app;

--- a/api/src/templates/components/tables.ts
+++ b/api/src/templates/components/tables.ts
@@ -139,13 +139,9 @@ export function generateQueriesTable(
     return `<p class="empty">${emptyMessage}</p>`;
   }
 
+  // Query text is intentionally NOT rendered. Search queries can contain
+  // proprietary contract source; only non-sensitive analytics are shown.
   const columns: TableColumn<(typeof queries)[0]>[] = [
-    {
-      key: "query",
-      label: "Query",
-      render: (q) =>
-        `<span style="word-break: break-word; white-space: normal;">${escapeHtml(q.query)}</span>`,
-    },
     { key: "endpoint", label: "Type" },
     {
       key: "topScore",

--- a/api/wrangler.private.toml
+++ b/api/wrangler.private.toml
@@ -1,0 +1,36 @@
+# PRIVATE deployment = the real search backend (src/index.ts).
+#
+# Deployed under a separate name/URL for the maintainer's own local use after
+# the public URL is switched to the deprecation stub (wrangler.toml). Point the
+# MCP client at it with `MIDNIGHT_API_URL=https://<this-worker-url>`.
+#
+# Deploy:  wrangler deploy -c wrangler.private.toml
+#
+# Before first deploy:
+#   1. Create a FRESH KV namespace so no previously-captured query text carries
+#      over, then put its id below:
+#        wrangler kv namespace create METRICS
+#   2. Set secrets (never commit these):
+#        wrangler secret put OPENAI_API_KEY   -c wrangler.private.toml
+#        wrangler secret put API_AUTH_TOKEN   -c wrangler.private.toml   # optional bearer auth
+#        wrangler secret put DASHBOARD_PASSWORD -c wrangler.private.toml # optional
+#   3. Delete the OLD public KV namespace to clear captured data at rest:
+#        wrangler kv namespace delete --namespace-id adc06e61998c417684ee353791077992
+name = "midnight-mcp-api-private"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+[vars]
+ENVIRONMENT = "production"
+
+# Vectorize index for semantic search (reuse the existing index — re-indexing
+# is expensive; it holds only public repo content, not query text).
+[[vectorize]]
+binding = "VECTORIZE"
+index_name = "midnight-code"
+
+# Metrics storage — use a FRESH namespace id (see step 1 above), NOT the old
+# public one, so no previously-captured query text is carried over.
+[[kv_namespaces]]
+binding = "METRICS"
+id = "REPLACE_WITH_FRESH_KV_NAMESPACE_ID"

--- a/api/wrangler.private.toml
+++ b/api/wrangler.private.toml
@@ -29,8 +29,8 @@ ENVIRONMENT = "production"
 binding = "VECTORIZE"
 index_name = "midnight-code"
 
-# Metrics storage — use a FRESH namespace id (see step 1 above), NOT the old
-# public one, so no previously-captured query text is carried over.
+# Metrics storage — fresh namespace (NOT the old public one), so no
+# previously-captured query text is carried over.
 [[kv_namespaces]]
 binding = "METRICS"
-id = "REPLACE_WITH_FRESH_KV_NAMESPACE_ID"
+id = "50ba310cab694aa6a57fa8d47adecacb"

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -1,23 +1,16 @@
+# PUBLIC deployment = deprecation stub (see src/stub.ts).
+#
+# midnight-mcp is retired; this URL now only redirects callers to the official
+# Kapa MCP + Midnight Expert. It intentionally has NO Vectorize / KV / OpenAI
+# bindings, so it cannot leak data or spend the OpenAI key.
+#
+# The real search backend (src/index.ts) is deployed separately under a private
+# name via `wrangler deploy -c wrangler.private.toml`.
+#
+# Deploy the stub:  wrangler deploy
 name = "midnight-mcp-api"
-main = "src/index.ts"
+main = "src/stub.ts"
 compatibility_date = "2024-12-01"
 
 [vars]
 ENVIRONMENT = "production"
-
-# Vectorize index for semantic search
-[[vectorize]]
-binding = "VECTORIZE"
-index_name = "midnight-code"
-
-# KV namespace for metrics storage
-[[kv_namespaces]]
-binding = "METRICS"
-id = "adc06e61998c417684ee353791077992"
-
-# Rate limiting
-# [[unsafe.bindings]]
-# name = "RATE_LIMITER"
-# type = "ratelimit"
-# namespace_id = "1"
-# simple = { limit = 60, period = 60 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-mcp",
-  "version": "0.2.21",
-  "description": "Model Context Protocol Server for Midnight Blockchain Development",
+  "version": "0.3.0",
+  "description": "[DEPRECATED — migrate to Kapa + Midnight Expert: https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert] Model Context Protocol Server for Midnight Blockchain Development",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,13 +1,13 @@
 {
   "name": "midnight-mcp",
-  "version": "0.2.0",
-  "description": "MCP Server for Midnight Blockchain Development - Compact smart contracts, zero-knowledge proofs, and TypeScript integration",
+  "version": "0.3.0",
+  "description": "[DEPRECATED — migrate to Kapa + Midnight Expert: https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert] MCP Server for Midnight Blockchain Development - Compact smart contracts, zero-knowledge proofs, and TypeScript integration",
   "author": "Idris Olubisi",
   "license": "MIT",
   "repository": "https://github.com/Olanetsoft/midnight-mcp",
   "homepage": "https://github.com/Olanetsoft/midnight-mcp#readme",
   "transport": ["stdio", "http"],
-  "tools": 26,
+  "tools": 31,
   "resources": 9,
   "prompts": 5,
   "keywords": [

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,8 +50,9 @@ const SERVER_INFO = {
   description: "MCP Server for Midnight Blockchain Development",
 };
 
-// Version check state
-let versionCheckResult: {
+// Version check state. midnight-mcp is deprecated, so it stays at the initial
+// "not outdated" value — see checkForUpdates below.
+const versionCheckResult: {
   isOutdated: boolean;
   latestVersion: string;
   updateMessage: string | null;
@@ -68,45 +69,15 @@ let toolCallCount = 0;
 const VERSION_CHECK_INTERVAL = 10; // Re-check every 10 tool calls
 
 /**
- * Check for updates against npm registry (runs at startup and periodically)
+ * Version-update check — disabled.
+ *
+ * midnight-mcp is deprecated, so it does not nag users to update to a
+ * retired npm package. The deprecation notice on every tool description and
+ * the midnight-new-mcp tool are the only "what to use instead" signal. Kept as
+ * a no-op so existing callers (startup + periodic) don't need to change.
  */
 async function checkForUpdates(): Promise<void> {
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
-
-    const response = await fetch(
-      "https://registry.npmjs.org/midnight-mcp/latest",
-      { signal: controller.signal }
-    );
-    clearTimeout(timeoutId);
-
-    if (!response.ok) return;
-
-    const data = (await response.json()) as { version: string };
-    const latestVersion = data.version;
-
-    if (latestVersion !== CURRENT_VERSION) {
-      versionCheckResult = {
-        isOutdated: true,
-        latestVersion,
-        lastChecked: Date.now(),
-        updateMessage: `🚨 UPDATE AVAILABLE: v${latestVersion} (you have v${CURRENT_VERSION})`,
-      };
-      logger.warn(
-        `Outdated version detected: v${CURRENT_VERSION} -> v${latestVersion}`
-      );
-    } else {
-      versionCheckResult = {
-        ...versionCheckResult,
-        lastChecked: Date.now(),
-      };
-    }
-  } catch (error: unknown) {
-    logger.debug("Version check failed (non-blocking)", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  return;
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -435,6 +435,16 @@ function registerCompletionsHandler(server: Server): void {
 }
 
 /**
+ * Prepended to every tool description so any client still using this MCP is
+ * redirected to the official replacements (Kapa + Midnight Expert) at the point
+ * of use. See the migration guide for details.
+ */
+const DEPRECATION_PREFIX =
+  "[DEPRECATED] midnight-mcp is being retired — use Kapa (docs Q&A) + " +
+  "Midnight Expert (dev): " +
+  "https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert — ";
+
+/**
  * Register tool handlers
  */
 function registerToolHandlers(server: Server): void {
@@ -444,7 +454,7 @@ function registerToolHandlers(server: Server): void {
     return {
       tools: allTools.map((tool) => ({
         name: tool.name,
-        description: tool.description,
+        description: DEPRECATION_PREFIX + tool.description,
         inputSchema: tool.inputSchema,
         // Include output schema if defined
         ...(tool.outputSchema && { outputSchema: tool.outputSchema }),

--- a/src/services/compiler.ts
+++ b/src/services/compiler.ts
@@ -1,10 +1,14 @@
 /**
- * Hosted Compact Compiler Service
+ * Compact Compiler Service (opt-in)
  *
- * Integrates with the hosted Compact compiler API to provide
- * real-time contract compilation and validation.
+ * Integrates with a Compact compiler HTTP API for real-time contract
+ * compilation and validation.
  *
- * API: https://compact-playground.up.railway.app
+ * Privacy: there is NO default compiler endpoint. Contract source is only ever
+ * sent to whatever COMPACT_COMPILER_URL points at, so with it unset nothing
+ * leaves the machine and the analyze tool falls back to local static analysis.
+ * Point COMPACT_COMPILER_URL at a compiler you run yourself to enable real
+ * compilation.
  */
 
 import { logger } from "../utils/logger.js";
@@ -13,9 +17,15 @@ import { logger } from "../utils/logger.js";
 // Configuration
 // =============================================================================
 
-const COMPILER_API_URL =
-  process.env.COMPACT_COMPILER_URL ||
-  "https://compact-playground.up.railway.app";
+/**
+ * Resolve the configured compiler endpoint at call time. Opt-in only: returns
+ * undefined when COMPACT_COMPILER_URL is unset, which keeps contract source on
+ * the local machine by default.
+ */
+function getConfiguredCompilerUrl(): string | undefined {
+  const url = process.env.COMPACT_COMPILER_URL?.trim();
+  return url ? url : undefined;
+}
 
 const COMPILER_TIMEOUT = 30000; // 30 seconds
 const MAX_CODE_SIZE = 100 * 1024; // 100 KB
@@ -106,11 +116,20 @@ export async function checkCompilerHealth(): Promise<{
   version?: string;
   error?: string;
 }> {
+  const url = getConfiguredCompilerUrl();
+  if (!url) {
+    return {
+      available: false,
+      error:
+        "No compiler configured. Set COMPACT_COMPILER_URL to a compiler you run yourself; contract source is never sent to a third-party compiler by default.",
+    };
+  }
+
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
 
   try {
-    const response = await fetch(`${COMPILER_API_URL}/health`, {
+    const response = await fetch(`${url}/health`, {
       method: "GET",
       signal: controller.signal,
     });
@@ -172,6 +191,19 @@ export async function compileContract(
     };
   }
 
+  const url = getConfiguredCompilerUrl();
+  if (!url) {
+    // No compiler configured — never send source off-box. The analyze tool
+    // treats serviceAvailable=false as "fall back to local static analysis".
+    return {
+      success: false,
+      message:
+        "No compiler service configured. Set COMPACT_COMPILER_URL to a compiler you run yourself to enable compilation; contract source is not sent to any third-party by default.",
+      error: "COMPILER_NOT_CONFIGURED",
+      serviceAvailable: false,
+    };
+  }
+
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), COMPILER_TIMEOUT);
 
@@ -189,7 +221,7 @@ export async function compileContract(
       options: requestBody.options,
     });
 
-    const response = await fetch(`${COMPILER_API_URL}/compile`, {
+    const response = await fetch(`${url}/compile`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -351,6 +383,6 @@ export async function fullCompile(code: string): Promise<CompilationResult> {
 /**
  * Get compiler service URL (for diagnostics)
  */
-export function getCompilerUrl(): string {
-  return COMPILER_API_URL;
+export function getCompilerUrl(): string | undefined {
+  return getConfiguredCompilerUrl();
 }

--- a/src/tools/deprecation/index.ts
+++ b/src/tools/deprecation/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Deprecation / redirect tool
+ *
+ * midnight-mcp is being retired in favour of the official Kapa MCP (docs Q&A)
+ * and Midnight Expert (hands-on dev). This tool surfaces the migration path at
+ * the point of use for anyone still running the server.
+ */
+
+import type { ExtendedToolDefinition } from "../../types/index.js";
+
+const BLOG_URL =
+  "https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert";
+
+export const deprecationTools: ExtendedToolDefinition[] = [
+  {
+    name: "midnight-new-mcp",
+    description:
+      "Show where midnight-mcp has moved. midnight-mcp is deprecated; Midnight " +
+      "now uses the official Kapa MCP (docs Q&A) and Midnight Expert (hands-on " +
+      "dev). Call this for the install commands and the migration guide.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      title: "➡️ Migrate off midnight-mcp",
+      category: "health",
+    },
+    handler: async () => ({
+      status: "deprecated",
+      message:
+        "midnight-mcp is being retired. Midnight has two official replacements.",
+      kapa: {
+        purpose: "Docs Q&A / search",
+        install:
+          "claude mcp add --transport http midnight https://midnight.mcp.kapa.ai",
+        url: "https://midnight.mcp.kapa.ai",
+      },
+      midnightExpert: {
+        purpose: "Hands-on dev (Claude Code plugins)",
+        install: "curl -fsSL https://midnightntwrk.expert/install.sh | bash",
+        url: "https://midnightntwrk.expert",
+      },
+      guide: BLOG_URL,
+    }),
+  },
+];

--- a/src/tools/health/handlers.ts
+++ b/src/tools/health/handlers.ts
@@ -76,6 +76,21 @@ export async function getStatus(_input: GetStatusInput) {
 }
 
 /**
+ * True if `candidate` is a strictly newer semver than `base` (major.minor.patch).
+ */
+function isNewerVersion(candidate: string, base: string): boolean {
+  const a = candidate.split(".").map((n) => parseInt(n, 10) || 0);
+  const b = base.split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x > y) return true;
+    if (x < y) return false;
+  }
+  return false;
+}
+
+/**
  * Check if current version is up to date with npm
  */
 export async function checkVersion(_input: CheckVersionInput) {
@@ -94,7 +109,10 @@ export async function checkVersion(_input: CheckVersionInput) {
 
     const data = (await response.json()) as { version: string };
     const latestVersion = data.version;
-    const isUpToDate = CURRENT_VERSION === latestVersion;
+    // Up to date unless npm has a STRICTLY newer version. Prevents a local
+    // build that is ahead of the last publish (e.g. an unpublished version
+    // bump) from being wrongly reported as outdated.
+    const isUpToDate = !isNewerVersion(latestVersion, CURRENT_VERSION);
 
     // Only include updateInstructions/newFeatures when actually outdated.
     // Omitting them (rather than returning null) keeps the result conformant
@@ -111,25 +129,22 @@ export async function checkVersion(_input: CheckVersionInput) {
       latestVersion,
       isUpToDate,
       message: isUpToDate
-        ? "✅ You are running the latest version!"
-        : `⚠️ UPDATE AVAILABLE: v${latestVersion} (you have v${CURRENT_VERSION})`,
+        ? "✅ You are running the latest published version. Note: midnight-mcp is deprecated — migrate to Kapa (docs Q&A) + Midnight Expert (dev): https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert"
+        : `⚠️ A newer version (v${latestVersion}) exists, but midnight-mcp is deprecated — migrate to Kapa (docs Q&A) + Midnight Expert (dev): https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert`,
     };
 
     if (!isUpToDate) {
       result.updateInstructions = {
-        step1:
-          "Clear npx cache: rm -rf ~/.npm/_npx (macOS/Linux) or del /s /q %LocalAppData%\\npm-cache\\_npx (Windows)",
-        step2:
-          "Restart Claude Desktop completely (Cmd+Q / Alt+F4, then reopen)",
-        step3:
-          "Or update config to use: npx -y midnight-mcp@latest (forces latest)",
-        alternative:
-          "You can also install globally: npm install -g midnight-mcp@latest",
+        note: "midnight-mcp is deprecated; updating is not recommended.",
+        kapa:
+          "claude mcp add --transport http midnight https://midnight.mcp.kapa.ai",
+        midnightExpert:
+          "curl -fsSL https://midnightntwrk.expert/install.sh | bash",
+        guide:
+          "https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert",
       };
       result.newFeatures = [
-        "Auto-update config tool - AI agents update your config automatically",
-        "midnight-extract-contract-structure - Static analysis with 10 pre-compilation checks",
-        "MCP Logging, Progress, Completions capabilities",
+        "midnight-mcp is deprecated — see the migration guide for the official replacements.",
       ];
     }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -91,6 +91,7 @@ export type {
 } from "../types/index.js";
 
 // Combined tool list for MCP server
+import { deprecationTools } from "./deprecation/index.js";
 import { searchTools } from "./search/index.js";
 import { analyzeTools } from "./analyze/index.js";
 import { repositoryTools } from "./repository/index.js";
@@ -100,6 +101,7 @@ import { metaTools } from "./meta/index.js";
 import type { ExtendedToolDefinition } from "../types/index.js";
 
 export const allTools: ExtendedToolDefinition[] = [
+  ...deprecationTools, // Redirect to the official replacements, surfaced first
   ...metaTools, // Discovery tools first for visibility
   ...searchTools,
   ...analyzeTools,
@@ -107,3 +109,6 @@ export const allTools: ExtendedToolDefinition[] = [
   ...healthTools,
   ...generationTools,
 ];
+
+// Re-export the redirect tool list for consumers/tests.
+export { deprecationTools } from "./deprecation/index.js";

--- a/src/tools/meta/tools.ts
+++ b/src/tools/meta/tools.ts
@@ -120,7 +120,7 @@ export const metaTools: ExtendedToolDefinition[] = [
   {
     name: "midnight-list-tool-categories",
     description:
-      "📋 DISCOVERY TOOL: List available tool categories for progressive exploration. Use this FIRST to understand what capabilities are available, then drill into specific categories with midnight-list-category-tools. Reduces cognitive load by organizing 28 tools into 7 logical groups.",
+      "📋 DISCOVERY TOOL: List available tool categories for progressive exploration. Use this FIRST to understand what capabilities are available, then drill into specific categories with midnight-list-category-tools. Reduces cognitive load by organizing the available tools into logical groups.",
     inputSchema: {
       type: "object" as const,
       properties: {

--- a/src/tools/repository/handlers.ts
+++ b/src/tools/repository/handlers.ts
@@ -7,6 +7,7 @@ import { githubClient, GitHubCommit } from "../../pipeline/index.js";
 import { releaseTracker } from "../../pipeline/releases.js";
 import {
   logger,
+  config,
   DEFAULT_REPOSITORIES,
   SelfCorrectionHints,
 } from "../../utils/index.js";
@@ -47,6 +48,21 @@ import type {
 export { extractContractStructure } from "./validation.js";
 
 /**
+ * Owners allowed for the bare "owner/repo" fall-through in resolveRepo().
+ * Seeded from the vetted alias + configured-repo lists and extended by the
+ * operator via MIDNIGHT_MCP_ALLOWED_REPO_OWNERS. Without this gate a
+ * prompt-injected model could read ANY GitHub repo — including private ones —
+ * with the operator's token.
+ */
+const ALLOWED_REPO_OWNERS: Set<string> = new Set(
+  [
+    ...Object.values(REPO_ALIASES).map((a) => a.owner),
+    ...DEFAULT_REPOSITORIES.map((r) => r.owner),
+    ...config.allowedRepoOwners,
+  ].map((owner) => owner.toLowerCase())
+);
+
+/**
  * Resolve repository name alias to owner/repo
  */
 export function resolveRepo(
@@ -65,10 +81,15 @@ export function resolveRepo(
     }
   }
 
-  // Assume it's a full org/repo name
+  // Assume it's a full org/repo name — but only for allowlisted owners.
+  // Returning null for anything else makes callers emit the UNKNOWN_REPO hint
+  // instead of reading an arbitrary repo with the operator's token.
   if (name.includes("/")) {
     const [owner, repo] = name.split("/");
-    return { owner, repo };
+    if (owner && repo && ALLOWED_REPO_OWNERS.has(owner.toLowerCase())) {
+      return { owner, repo };
+    }
+    return null;
   }
 
   return null;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -12,8 +12,18 @@ const ConfigSchema = z.object({
     .string()
     .default("https://midnight-mcp-api.midnightmcp.workers.dev"),
 
+  // Optional bearer token sent to the hosted API. Needed when pointing
+  // MIDNIGHT_API_URL at a private/self-hosted backend that requires auth.
+  hostedApiToken: z.string().optional(),
+
   // GitHub
   githubToken: z.string().optional(),
+
+  // Extra GitHub repo owners allowed for the resolveRepo() org/repo
+  // fall-through, on top of the built-in vetted list. Comma-separated via
+  // MIDNIGHT_MCP_ALLOWED_REPO_OWNERS. Lets local users add their own repos
+  // without reopening arbitrary-repo access.
+  allowedRepoOwners: z.array(z.string()).default([]),
 
   // Vector Database (only needed for local mode)
   chromaUrl: z.string().default("http://localhost:8000"),
@@ -43,7 +53,13 @@ function loadConfig(): Config {
   const rawConfig = {
     mode: isLocalMode ? "local" : "hosted",
     hostedApiUrl: process.env.MIDNIGHT_API_URL,
+    hostedApiToken: process.env.MIDNIGHT_API_TOKEN,
     githubToken: process.env.GITHUB_TOKEN,
+    allowedRepoOwners: process.env.MIDNIGHT_MCP_ALLOWED_REPO_OWNERS
+      ? process.env.MIDNIGHT_MCP_ALLOWED_REPO_OWNERS.split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : undefined,
     chromaUrl: process.env.CHROMA_URL,
     openaiApiKey: process.env.OPENAI_API_KEY,
     embeddingModel: process.env.EMBEDDING_MODEL,

--- a/src/utils/hosted-api.ts
+++ b/src/utils/hosted-api.ts
@@ -151,6 +151,11 @@ async function makeRequest<T>(
       headers: {
         "Content-Type": "application/json",
         "User-Agent": "midnight-mcp",
+        // Send bearer auth when the backend requires it (private/self-hosted
+        // deployments that set MIDNIGHT_API_TOKEN).
+        ...(config.hostedApiToken
+          ? { Authorization: `Bearer ${config.hostedApiToken}` }
+          : {}),
         ...options.headers,
       },
     });

--- a/tests/analyze.test.ts
+++ b/tests/analyze.test.ts
@@ -136,12 +136,21 @@ describe("Compile Contract", () => {
   const mockFetch = vi.fn();
   const originalFetch = globalThis.fetch;
 
+  const prevCompilerUrl = process.env.COMPACT_COMPILER_URL;
+
   beforeAll(() => {
     globalThis.fetch = mockFetch;
+    // Compiler is opt-in; configure an endpoint so the service path is tested.
+    process.env.COMPACT_COMPILER_URL = "https://compiler.test.local";
   });
 
   afterAll(() => {
     globalThis.fetch = originalFetch;
+    if (prevCompilerUrl === undefined) {
+      delete process.env.COMPACT_COMPILER_URL;
+    } else {
+      process.env.COMPACT_COMPILER_URL = prevCompilerUrl;
+    }
   });
 
   beforeEach(() => {
@@ -307,6 +316,35 @@ export circuit getValue(): Field {
     expect(result.error).toBe("INVALID_INPUT");
   });
 
+  it("does not send source off-box when no compiler is configured", async () => {
+    const saved = process.env.COMPACT_COMPILER_URL;
+    delete process.env.COMPACT_COMPILER_URL;
+    mockFetch.mockClear();
+
+    try {
+      const result = (await compileContract({
+        code: `
+ledger {
+  counter: Counter;
+}
+
+export circuit increment(): Void {
+  ledger.counter.increment(1);
+}
+        `,
+      })) as Record<string, unknown>;
+
+      // No network call is made, so contract source never leaves the machine.
+      expect(mockFetch).not.toHaveBeenCalled();
+      // Falls back to local static analysis instead of erroring.
+      expect(result.success).toBe(true);
+      expect(result.validationType).toBe("static-analysis-fallback");
+      expect(result.serviceAvailable).toBe(false);
+    } finally {
+      process.env.COMPACT_COMPILER_URL = saved;
+    }
+  });
+
   it("should validate input - reject oversized code", async () => {
     const result = (await compileContract({
       code: "x".repeat(200 * 1024), // 200KB
@@ -321,12 +359,21 @@ describe("Compiler Status", () => {
   const mockFetch = vi.fn();
   const originalFetch = globalThis.fetch;
 
+  const prevCompilerUrl = process.env.COMPACT_COMPILER_URL;
+
   beforeAll(() => {
     globalThis.fetch = mockFetch;
+    // Compiler is opt-in; configure an endpoint so the service path is tested.
+    process.env.COMPACT_COMPILER_URL = "https://compiler.test.local";
   });
 
   afterAll(() => {
     globalThis.fetch = originalFetch;
+    if (prevCompilerUrl === undefined) {
+      delete process.env.COMPACT_COMPILER_URL;
+    } else {
+      process.env.COMPACT_COMPILER_URL = prevCompilerUrl;
+    }
   });
 
   beforeEach(() => {


### PR DESCRIPTION
Midnight has standardised on the official **Kapa MCP** (docs Q&A) and **Midnight Expert** (hands-on dev), so this winds `midnight-mcp` down cleanly: switch off the public hosted surface, redirect users at the point of use, and close the security issues that would otherwise keep affecting local installs. The repo and local use are preserved.

Migration guide: https://docs.midnight.network/blog/migrating-to-kapa-and-midnight-expert

## Hosted surface — stub the public Worker
- `api/src/stub.ts` — new deprecation stub covering every route. Returns HTTP 200 with the redirect in `warnings[]` (so the message surfaces through the MCP client instead of being swallowed as an error), keeps `/health` healthy, and serves a static dashboard page. Holds **no** OpenAI key, Vectorize, or KV — it cannot leak data or spend the key.
- `api/wrangler.toml` now deploys the **stub** to the public name (default `wrangler deploy`).
- `api/wrangler.private.toml` — deploys the **real** backend (`src/index.ts`) under a private name for continued local use, with inline steps for a fresh KV namespace, secrets, and deleting the old KV.
- Optional bearer auth: `API_AUTH_TOKEN` on the Worker, sent by the client via `MIDNIGHT_API_TOKEN`, so a retained private backend isn't an open, key-burning endpoint.

## Redirect at the point of use
- Deprecation + migration-guide note prepended to **every** tool description (single choke point in the `ListTools` handler).
- New `midnight-new-mcp` tool returning the Kapa + Midnight Expert install commands and the migration guide, surfaced first in `allTools`.
- Deprecation banner in `README.md` and `server.json`; version bumped to `0.3.0`.

## Security (lives in the package, so it affects anyone still running it)
- **Compiler is now opt-in.** No default third-party endpoint — contract source never leaves the machine unless `COMPACT_COMPILER_URL` points at a compiler you run yourself. Falls back to local static analysis otherwise. (Previously source was POSTed to a third-party compiler by default, even with `MIDNIGHT_LOCAL=true`.)
- **`resolveRepo()` allowlist.** The bare `owner/repo` fall-through no longer reads arbitrary GitHub repos with the operator's token. Access is gated to the vetted alias/config list, extendable via `MIDNIGHT_MCP_ALLOWED_REPO_OWNERS`.

## Docs
- `.env.example` now documents `MIDNIGHT_API_URL` / `MIDNIGHT_API_TOKEN`, `COMPACT_COMPILER_URL`, and the repo allowlist.

## Also included
- `stop logging and exposing search query text` (`3bdceaa`) — the earlier query-log fix that stops search query text (which can contain contract source) being captured and served from the public stats endpoint / dashboard.

## Verification
- Root typecheck ✓, Worker typecheck ✓
- 219 tests pass (incl. a new test asserting no source leaves the box when no compiler is configured)
- Build ✓, lint 0 errors